### PR TITLE
Downloaders: Data members and minor PR fixes.

### DIFF
--- a/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoContentDownloader.h
+++ b/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoContentDownloader.h
@@ -17,8 +17,8 @@ typedef void(^PhotoCompletionBlock)(UIImage *);
 
 /// Retrieves the photo content from the given \c metadata.
 /// Upon completion, the given \c completion block is called.
-- (void)fetchPhotoContent:(FlickrPhotoMetadata *)metadata
-               completion:(PhotoCompletionBlock)completion;
+- (void)fetchImageFromMetaData:(FlickrPhotoMetadata *)metadata
+                    completion:(PhotoCompletionBlock)completion;
 
 @end
 

--- a/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoContentDownloader.m
+++ b/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoContentDownloader.m
@@ -12,21 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FlickrPhotoContentDownloader
 
-- (void)fetchPhotoContent:(FlickrPhotoMetadata *)metadata
-               completion:(PhotoCompletionBlock)completion {
+- (void)fetchImageFromMetaData:(FlickrPhotoMetadata *)metadata
+                    completion:(PhotoCompletionBlock)completion {
   NSURLRequest *request = [NSURLRequest requestWithURL:metadata.url];
   NSURLSessionConfiguration *configuration =
       [NSURLSessionConfiguration ephemeralSessionConfiguration];
   NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
   NSString *errorMessage = @"Error while trying to download data from url %@: %@";
   NSURLSessionDownloadTask *task = [session downloadTaskWithRequest:request
-                                                  completionHandler:^(NSURL * _Nullable localfile,
-                                                                      NSURLResponse *respones,
+                                                  completionHandler:^(NSURL * _Nullable path,
+                                                                      NSURLResponse *response,
                                                                       NSError * _Nullable error) {
                                                     if (!error) {
                                                       if ([request.URL isEqual:metadata.url]) {
                                                         NSData *data =
-                                                            [NSData dataWithContentsOfURL:localfile];
+                                                            [NSData dataWithContentsOfURL:path];
                                                         completion([UIImage imageWithData:data]);
                                                       }
                                                     }

--- a/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoMetadataDownloader.h
+++ b/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrPhotoMetadataDownloader.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class FlickrPlacePhotoMetadata;
+@class FlickrPlaceMetadata;
 
 @class FlickrPhotoMetadata;
 
@@ -18,7 +18,7 @@ typedef void(^PhotoMetadataCompletionBlock)(NSArray<FlickrPhotoMetadata *> *);
 /// Retrieves \c NSDictionary photos content of a given place \c metadata.
 /// \c maxNumberOfPhotoMetadata limits the number of retrieved photo metadata.
 /// Upon completion, the given \c completion is called.
-- (void)fetchPhotoMetadataFromPlaceMetadata:(FlickrPlacePhotoMetadata *)metadata
+- (void)fetchPhotoMetadataFromPlaceMetadata:(FlickrPlaceMetadata *)metadata
                    maxNumberOfPhotoMetadata:(int)maxNumberOfPhotoMetadata
                                  completion:(PhotoMetadataCompletionBlock)completion;
 

--- a/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrTopPlaceDownloader.h
+++ b/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrTopPlaceDownloader.h
@@ -5,10 +5,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class FlickrPlacePhotoMetadata;
+@class FlickrPlaceMetadata;
+
+/// Mapping of countries to corresponding ordered collections of Flickr place metadata.
+typedef NSDictionary<NSString *, NSArray<FlickrPlaceMetadata *> *> FlickrPlaceMetadataDictionary;
+
+/// Mutable mapping of countries to corresponding ordered collections of Flickr place metadata.
+typedef NSMutableDictionary<NSString *,
+                            NSMutableArray<FlickrPlaceMetadata *> *> MutableFlickrPlaceMetadataDictionary;
 
 /// Completion block that executes in the end of the top places list download.
-typedef void(^TopPlacesCompletionBlock)(NSArray<FlickrPlacePhotoMetadata *> *);
+/// Keys in dictionary represent country name and the values represent places.
+typedef void(^TopPlacesCompletionBlock)(FlickrPlaceMetadataDictionary *);
 
 /// Immutable object that represents a Flickr top places downloader.
 @interface FlickrTopPlaceDownloader : NSObject

--- a/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrTopPlaceDownloader.m
+++ b/FlickrPhotos/FlickrPhotos/Model/Downloader/FlickrTopPlaceDownloader.m
@@ -5,7 +5,7 @@
 
 #import "FlickrFetcher.h"
 #import "FlickrMetadataDownloader.h"
-#import "FlickrPlacePhotoMetadata.h"
+#import "FlickrPlaceMetadata.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,34 +18,77 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FlickrTopPlaceDownloader
 
+#pragma mark -
+#pragma mark Initialization
+#pragma mark -
+
 - (instancetype)init {
   if (self = [super init]) {
-    self.downloader =[[FlickrMetadataDownloader alloc] init];
+    self.downloader = [[FlickrMetadataDownloader alloc] init];
   }
   return self;
 }
+
+#pragma mark -
+#pragma mark Public API
+#pragma mark -
 
 - (void)fetchPlaces:(TopPlacesCompletionBlock)completion {
   CompletionBlock extractTopPlacesData = ^(NSDictionary *data) {
     NSArray *places = [data valueForKeyPath:FLICKR_RESULTS_PLACES];
     if (!places.count) {
-      NSLog(@"No top places available");
+      NSLog(@"No top places available.");
       return;
     }
     
-     NSMutableArray<FlickrPlacePhotoMetadata *> *downloadedPlaces =
-        [NSMutableArray<FlickrPlacePhotoMetadata *> arrayWithCapacity:places.count];
+    MutableFlickrPlaceMetadataDictionary *topPlaces =
+        [[NSMutableDictionary alloc] initWithCapacity:places.count];
     for (NSDictionary *place in places) {
-      FlickrPlacePhotoMetadata *placeMetadata =
-          [[FlickrPlacePhotoMetadata alloc] initWithPlaceID:[place valueForKeyPath:FLICKR_PLACE_ID]
-                                                country:@"" city:@"" region:@""];
-      [downloadedPlaces addObject:placeMetadata];
+      NSString *details = [place valueForKeyPath:FLICKR_PLACE_NAME];
+      FlickrPlaceMetadata *placeMetadata =
+          [[FlickrPlaceMetadata alloc] initWithPlaceID:[place valueForKeyPath:FLICKR_PLACE_ID]
+                                               country:[self countryFromPlaceInformation:details]
+                                                  city:[self cityFromPlaceInformation:details]
+                                                region:[self regionFromPlaceInformation:details]];
+      NSMutableArray<FlickrPlaceMetadata *> *arrayForKey = [topPlaces objectForKey:placeMetadata.country];
+      if (!arrayForKey) {
+        arrayForKey = [[NSMutableArray alloc] init];
+        [arrayForKey addObject:placeMetadata];
+        [topPlaces setObject:arrayForKey forKey:placeMetadata.country];
+      } else {
+        [arrayForKey addObject:placeMetadata];
+        [topPlaces setObject:arrayForKey forKey:placeMetadata.country];
+      }
     }
-    completion([downloadedPlaces copy]);
+    completion([FlickrTopPlaceDownloader deepCopy:topPlaces]);
   };
   
-  NSURL *topPlacesURL = [FlickrFetcher URLforTopPlaces];
-  [self.downloader retrieveFromURL:topPlacesURL callingCompletion:extractTopPlacesData];
+  [self.downloader retrieveFromURL:[FlickrFetcher URLforTopPlaces]
+                 callingCompletion:extractTopPlacesData];
+}
+
++ (FlickrPlaceMetadataDictionary *)deepCopy:(MutableFlickrPlaceMetadataDictionary *)places {
+  NSMutableDictionary<NSString *, NSArray<FlickrPlaceMetadata *> *> *mapping =
+      [[NSMutableDictionary alloc] initWithCapacity:places.count];
+  for (NSString *country in places.allKeys) {
+    mapping[country] = [places[country] copy];
+  }
+  return [mapping copy];
+}
+
+- (NSString *)cityFromPlaceInformation:(NSString *)placeInformation {
+  NSArray *details = [placeInformation componentsSeparatedByString:@","] ;
+  return [details.firstObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+}
+
+- (NSString *)countryFromPlaceInformation:(NSString *)placeInformation {
+  NSArray *details = [placeInformation componentsSeparatedByString:@","];
+  return [details.lastObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+}
+
+- (NSString *)regionFromPlaceInformation:(NSString *)placeInformation {
+  NSArray *details = [placeInformation componentsSeparatedByString:@","];
+  return [details[1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 
 @end


### PR DESCRIPTION
This commit adds the FlickrTopPlaceDownloader,
FlickrPhotoMetadataDownloader and FlickrPhotoContentDownloader classes.

FlickrTopPlaceDownloader:
Added PR fixes and usage of FlickrPlaceMetadata new data members.

FlickrPhotoMetadataDownloader:
Added PR fixes and usage of FlickrPhotoMetadata new data members.

FlickrPhotoContentDownloader:
Added PR fixes.